### PR TITLE
fix(shub): increases image size limit

### DIFF
--- a/shub/image/test.py
+++ b/shub/image/test.py
@@ -18,7 +18,7 @@ the test command is also executed automatically as a part of build command
 in its end (if you do not provide -S/--skip-tests parameter explicitly).
 """
 
-IMAGE_SIZE_LIMIT = 5 * 1024 * 1024 * 1024  # 5GB
+IMAGE_SIZE_LIMIT = 6 * 1024 * 1024 * 1024  # 6GB
 CONTRACT_CMD_NOT_FOUND_WARNING = (
     "Command %s is not found in the image. "
     "Please make sure you provided it according to Scrapy Cloud contract "


### PR DESCRIPTION
I need to increase temporary the image limit size to test the python image python:3.11.10-slim-bookworm instead of the playwright one.